### PR TITLE
Restore fake git driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/markwalet/laravel-git-state/compare/v1.11.1...main)
 
+### Added
+- Restored the `FakeGitDriver` for testing and non-production use cases.
+
+### Changed
+- Re-enabled fake-driver coverage in the factory, manager, and service provider tests.
+
 ## [v1.11.1 (2026-03-27)](https://github.com/markwalet/laravel-git-state/compare/v1.11.0...v1.11.1)
 
 ### Added

--- a/config/git-state.php
+++ b/config/git-state.php
@@ -24,7 +24,7 @@ return [
     | The given configuration options should be fine for most projects. But
     | feel free to change them however you like.
     |
-    | Supported drivers are: 'exec', 'file'.
+    | Supported drivers are: 'exec', 'file', 'fake'.
     |
     */
 

--- a/src/Drivers/FakeGitDriver.php
+++ b/src/Drivers/FakeGitDriver.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MarkWalet\GitState\Drivers;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+
+class FakeGitDriver implements GitDriver
+{
+    private string $branch;
+
+    private string $hash;
+
+    private Carbon $timestamp;
+
+    private string $title;
+
+    private string $description;
+
+    /**
+     * GitDriverInterface constructor.
+     *
+     * @param array<string, scalar> $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->branch = (string) Arr::get($config, 'branch', 'master');
+        $this->hash = (string) Arr::get($config, 'hash', '');
+        $this->timestamp = Carbon::createFromTimestampUTC((int) Arr::get($config, 'timestamp', 0));
+        $this->title = (string) Arr::get($config, 'title', '');
+        $this->description = (string) Arr::get($config, 'description', '');
+    }
+
+    public function currentBranch(): string
+    {
+        return $this->branch;
+    }
+
+    public function latestCommitHash(bool $short = false): string
+    {
+        return $short
+            ? mb_substr($this->hash, 0, 7)
+            : trim($this->hash);
+    }
+
+    public function latestCommitTimestamp(): Carbon
+    {
+        return $this->timestamp;
+    }
+
+    public function latestCommitTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function latestCommitDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function updateCurrentBranch(string $branch): void
+    {
+        $this->branch = $branch;
+    }
+
+    public function updateLatestCommit(string $hash): void
+    {
+        $this->hash = $hash;
+    }
+
+    public function updateLatestCommitTimestamp(int $timestamp): void
+    {
+        $this->timestamp = Carbon::createFromTimestampUTC($timestamp);
+    }
+
+    public function updateLatestCommitTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function updateLatestCommitDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+}

--- a/src/GitDriverFactory.php
+++ b/src/GitDriverFactory.php
@@ -3,6 +3,7 @@
 namespace MarkWalet\GitState;
 
 use MarkWalet\GitState\Drivers\ExecGitDriver;
+use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\FileGitDriver;
 use MarkWalet\GitState\Drivers\GitDriver;
 use MarkWalet\GitState\Exceptions\MissingDriverException;
@@ -34,6 +35,8 @@ class GitDriverFactory
     protected function createDriver(string $driver, array $config): GitDriver
     {
         switch ($driver) {
+            case 'fake':
+                return new FakeGitDriver($config);
             case 'exec':
                 return new ExecGitDriver($config);
             case 'file':

--- a/tests/Drivers/FakeGitDriverTest.php
+++ b/tests/Drivers/FakeGitDriverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MarkWalet\GitState\Tests\Drivers;
+
+use Carbon\Carbon;
+use MarkWalet\GitState\Drivers\FakeGitDriver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class FakeGitDriverTest extends TestCase
+{
+    #[Test]
+    public function it_can_set_the_current_branch_from_configuration(): void
+    {
+        $git = new FakeGitDriver(['branch' => 'feature-12']);
+
+        $branch = $git->currentBranch();
+
+        $this->assertEquals('feature-12', $branch);
+    }
+
+    #[Test]
+    public function the_current_branch_defaults_to_master(): void
+    {
+        $git = new FakeGitDriver;
+
+        $branch = $git->currentBranch();
+
+        $this->assertEquals('master', $branch);
+    }
+
+    #[Test]
+    public function it_can_update_the_current_branch(): void
+    {
+        $git = new FakeGitDriver;
+        $git->updateCurrentBranch('new-feature');
+
+        $branch = $git->currentBranch();
+
+        $this->assertEquals('new-feature', $branch);
+    }
+
+    #[Test]
+    public function it_can_set_the_latest_commit_metadata_from_configuration(): void
+    {
+        $git = new FakeGitDriver([
+            'hash' => '3859cf1331b88a361140eff8ff8a2a926eab12f9',
+            'timestamp' => 1594823686,
+            'title' => 'Latest test commit',
+            'description' => "This is the commit description.\n\nIt spans multiple lines.",
+        ]);
+
+        $this->assertEquals('3859cf1', $git->latestCommitHash(true));
+        $this->assertEquals('2020-07-15T14:34:46+00:00', $git->latestCommitTimestamp()->toIso8601String());
+        $this->assertEquals('Latest test commit', $git->latestCommitTitle());
+        $this->assertEquals("This is the commit description.\n\nIt spans multiple lines.", $git->latestCommitDescription());
+    }
+
+    #[Test]
+    public function it_can_update_the_latest_commit_metadata(): void
+    {
+        $git = new FakeGitDriver;
+        $git->updateLatestCommit('3859cf1331b88a361140eff8ff8a2a926eab12f9');
+        $git->updateLatestCommitTimestamp(1594823686);
+        $git->updateLatestCommitTitle('Latest test commit');
+        $git->updateLatestCommitDescription("This is the commit description.\n\nIt spans multiple lines.");
+
+        $this->assertEquals('3859cf1331b88a361140eff8ff8a2a926eab12f9', $git->latestCommitHash());
+        $this->assertInstanceOf(Carbon::class, $git->latestCommitTimestamp());
+        $this->assertEquals('2020-07-15T14:34:46+00:00', $git->latestCommitTimestamp()->toIso8601String());
+        $this->assertEquals('Latest test commit', $git->latestCommitTitle());
+        $this->assertEquals("This is the commit description.\n\nIt spans multiple lines.", $git->latestCommitDescription());
+    }
+}

--- a/tests/GitDriverFactoryTest.php
+++ b/tests/GitDriverFactoryTest.php
@@ -4,6 +4,7 @@ namespace MarkWalet\GitState\Tests;
 
 use InvalidArgumentException;
 use MarkWalet\GitState\Drivers\ExecGitDriver;
+use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\FileGitDriver;
 use MarkWalet\GitState\Exceptions\MissingDriverException;
 use MarkWalet\GitState\GitDriverFactory;
@@ -13,15 +14,15 @@ use PHPUnit\Framework\TestCase;
 class GitDriverFactoryTest extends TestCase
 {
     #[Test]
-    public function it_throws_an_exception_when_the_fake_driver_is_requested(): void
+    public function it_can_create_a_fake_driver(): void
     {
         $factory = new GitDriverFactory;
 
-        $this->expectException(MissingDriverException::class);
-
-        $factory->make([
+        $driver = $factory->make([
             'driver' => 'fake',
         ]);
+
+        $this->assertInstanceOf(FakeGitDriver::class, $driver);
     }
 
     #[Test]

--- a/tests/GitStateManagerTest.php
+++ b/tests/GitStateManagerTest.php
@@ -2,8 +2,8 @@
 
 namespace MarkWalet\GitState\Tests;
 
+use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\FileGitDriver;
-use MarkWalet\GitState\Drivers\GitDriver;
 use MarkWalet\GitState\Exceptions\MissingConfigurationException;
 use MarkWalet\GitState\GitDriverFactory;
 use MarkWalet\GitState\GitStateManager;
@@ -32,26 +32,18 @@ class GitStateManagerTest extends TestCase
     #[Test]
     public function it_uses_the_default_driver_if_no_driver_is_specified(): void
     {
-        $driver = $this->createMock(GitDriver::class);
-
-        $factory = $this->createMock(GitDriverFactory::class);
-        $factory->expects($this->once())
-            ->method('make')
-            ->with(['driver' => 'mock'])
-            ->willReturn($driver);
-
-        $manager = new GitStateManager($factory, [
-            'default' => 'test-instance',
+        $manager = new GitStateManager(new GitDriverFactory, [
+            'default' => 'fake-instance',
             'drivers' => [
-                'test-instance' => [
-                    'driver' => 'mock',
+                'fake-instance' => [
+                    'driver' => 'fake',
                 ],
             ],
         ]);
 
-        $resolvedDriver = $manager->driver();
+        $driver = $manager->driver();
 
-        $this->assertSame($driver, $resolvedDriver);
+        $this->assertInstanceOf(FakeGitDriver::class, $driver);
     }
 
     #[Test]
@@ -63,7 +55,7 @@ class GitStateManagerTest extends TestCase
 
         $this->expectException(MissingConfigurationException::class);
 
-        $manager->driver('test');
+        $manager->driver('fake');
     }
 
     #[Test]
@@ -81,29 +73,22 @@ class GitStateManagerTest extends TestCase
     #[Test]
     public function it_keeps_track_of_all_active_drivers(): void
     {
-        $firstDriver = $this->createMock(GitDriver::class);
-        $secondDriver = $this->createMock(GitDriver::class);
-
-        $factory = $this->createMock(GitDriverFactory::class);
-        $factory->expects($this->exactly(2))
-            ->method('make')
-            ->willReturnOnConsecutiveCalls($firstDriver, $secondDriver);
-
-        $manager = new GitStateManager($factory, [
-            'default' => 'first-instance',
+        $manager = new GitStateManager(new GitDriverFactory, [
+            'default' => 'fake-instance',
             'drivers' => [
-                'first-instance' => [
-                    'driver' => 'mock',
+                'fake-instance' => [
+                    'driver' => 'fake',
                 ],
                 'other-instance' => [
-                    'driver' => 'mock',
+                    'driver' => 'exec',
+                    'path' => __DIR__.'/test-data/on-nested-feature',
                 ],
             ],
         ]);
 
         $before = $manager->getActiveDrivers();
 
-        $manager->driver('first-instance');
+        $manager->driver('fake-instance');
         $manager->driver('other-instance');
 
         $after = $manager->getActiveDrivers();
@@ -118,7 +103,7 @@ class GitStateManagerTest extends TestCase
         $factory = $this->createMock(GitDriverFactory::class);
         $factory->expects($this->exactly(2))->method('make');
         $manager = new GitStateManager($factory, [
-            'default' => 'mock',
+            'default' => 'fake-instance',
             'drivers' => [
                 'mock' => [],
                 'test' => [],

--- a/tests/GitStateServiceProviderTest.php
+++ b/tests/GitStateServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace MarkWalet\GitState\Tests;
 
+use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\GitDriver;
 use MarkWalet\GitState\Facades\GitState;
 use MarkWalet\GitState\GitStateManager;
@@ -28,18 +29,12 @@ class GitStateServiceProviderTest extends LaravelTestCase
     #[Test]
     public function it_binds_the_correct_driver_to_the_application_based_on_the_configuration(): void
     {
-        $driverMock = $this->createMock(GitDriver::class);
-        $managerMock = $this->createMock(GitStateManager::class);
-        $managerMock->expects($this->once())
-            ->method('driver')
-            ->with(null)
-            ->willReturn($driverMock);
-
-        $this->app->instance(GitStateManager::class, $managerMock);
+        $this->app['config']['git-state.default'] = 'test';
+        $this->app['config']['git-state.drivers.test'] = ['driver' => 'fake'];
 
         $driver = $this->app->make(GitDriver::class);
 
-        $this->assertSame($driverMock, $driver);
+        $this->assertInstanceOf(FakeGitDriver::class, $driver);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- restore the fake git driver and wire it back into the driver factory
- restore fake-driver based tests for the factory, manager, and service provider
- document the restoration under Unreleased in the changelog

## Why
The fake driver was removed in #48, but it is still needed for package testing and supported usage.